### PR TITLE
fixes typo in models

### DIFF
--- a/models/api.models.js
+++ b/models/api.models.js
@@ -1,7 +1,7 @@
 const fs = require("fs/promises")
 
 exports.selectApi = () => {
-    return fs.readFile("endpoint.json", "utf-8").then((contents) => {
+    return fs.readFile("endpoints.json", "utf-8").then((contents) => {
         return contents
     })
 }


### PR DESCRIPTION
there was a typo in the /api models, so this fixes it.
