### PR TITLE
12 get article comment count

### DIFF
--- a/__tests__/integrations.test.js
+++ b/__tests__/integrations.test.js
@@ -58,7 +58,7 @@ describe("GET /api/articles/:article_id", () => {
       .get("/api/articles/1")
       .expect(200)
       .then(({ body }) => {
-        expect(body.article).toEqual({
+        expect(body.article).toMatchObject({
           article_id: 1,
           title: "Living in the shadow of a great man",
           topic: "mitch",
@@ -68,6 +68,24 @@ describe("GET /api/articles/:article_id", () => {
           votes: 100,
           article_img_url:
             "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          comment_count: 11,
+        });
+      });
+  });
+  test("GET 200: responds with an object that has a comment_count of 0 for an article that has no comments", () => {
+    return request(app)
+      .get("/api/articles/2")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body.article).toMatchObject({
+          title: "Sony Vaio; or, The Laptop",
+          topic: "mitch",
+          author: "icellusedkars",
+          body: "Call me Mitchell. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would buy a laptop about a little and see the codey part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to coding as soon as I can. This is my substitute for pistol and ball. With a philosophical flourish Cato throws himself upon his sword; I quietly take to the laptop. There is nothing surprising in this. If they but knew it, almost all men in their degree, some time or other, cherish very nearly the same feelings towards the the Vaio with me.",
+          created_at: "2020-10-16T05:03:00.000Z",
+          article_img_url:
+            "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          comment_count: 0,
         });
       });
   });
@@ -139,7 +157,7 @@ describe("GET /api/articles", () => {
       .get("/api/articles?topic=paper")
       .expect(200)
       .then(({ body }) => {
-        expect(body.articles.length).toBe(0)
+        expect(body.articles.length).toBe(0);
       });
   });
   test("GET 404: sends an error message when topic query is invalid", () => {

--- a/endpoints.json
+++ b/endpoints.json
@@ -38,7 +38,8 @@
         "body": "article_contents",
         "created_at": "2017-07-09T21:11:00.000Z",
         "votes": 10,
-        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+        "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 11
       }
     }
   },

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -21,8 +21,11 @@ exports.selectArticles = (topic) => {
 exports.selectArticleById = (article_id) => {
   return db
     .query(
-      `SELECT * FROM articles
-    WHERE article_id = $1`,
+      `SELECT articles.*, COUNT(comments.comment_id) :: INT comment_count FROM articles
+      LEFT JOIN comments
+      ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id`,
       [article_id]
     )
     .then(({ rows }) => {


### PR DESCRIPTION
adds functionality to the GET /api/articles/:article_id to include a comment count for each comment